### PR TITLE
TextSlider input

### DIFF
--- a/ui/text-slider.reel/text-slider.css
+++ b/ui/text-slider.reel/text-slider.css
@@ -1,6 +1,26 @@
 
+.matte-TextSlider {
+    display: inline-block;
+    min-width: 1em;
+    outline: none;
+    position: relative;
+}
+
 .matte-TextSlider-input {
     display: none;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding: 0;
+    margin: 0;
+    outline: none;
+    font: inherit;
+    line-height: inherit;
+    text-align: inherit;
+    border: none;
+    background: hsla(0,0%,0%,.1);
 }
 
 .matte-TextSlider--editing .matte-TextSlider-input {
@@ -11,6 +31,7 @@
     border-bottom: 1px dotted #000;
 }
 
-.matte-TextSlider--editing .matte-TextSlider-value, .matte-TextSlider--editing .matte-TextSlider-label {
-    display: none;
+.matte-TextSlider--editing .matte-TextSlider-value, 
+.matte-TextSlider--editing .matte-TextSlider-label {
+    visibility: hidden;
 }


### PR DESCRIPTION
Now when you click, it doesn't resize the `TextSlider`. It should feel more like "in-place" editing.

The only issue is when there is just a single digit and you type a couple digits.. then it gets cut off till you hit enter. But in a typical use case. You would set the width of the `TextSlider` to something that fits your layout.

![text-slider](https://f.cloud.github.com/assets/378023/556855/64ca545a-c3e3-11e2-919b-1ecec329f316.png)
