### PR TITLE
changed binding to label on confirm

### DIFF
--- a/ui/popup/confirm.reel/confirm.html
+++ b/ui/popup/confirm.reel/confirm.html
@@ -25,7 +25,7 @@
             }
         },
         "bindings": {
-            "value": {"<-": "@owner.okLabel"}
+            "label": {"<-": "@owner.okLabel"}
         },
         "listeners": [
             {
@@ -45,7 +45,7 @@
             }
         },
         "bindings": {
-            "value": {"<-": "@owner.cancelLabel"}
+            "label": {"<-": "@owner.cancelLabel"}
         },
         "listeners": [
             {


### PR DESCRIPTION
Cancel and OK buttons always showed defaults, now they take in their button text from the show options
