### PR TITLE
Init selection as empty array.

### DIFF
--- a/ui/autocomplete/autocomplete.reel/autocomplete.js
+++ b/ui/autocomplete/autocomplete.reel/autocomplete.js
@@ -415,6 +415,8 @@ var Autocomplete = exports.Autocomplete = TextInput.specialize(/** @lends module
 
                 // create the Repetition for the suggestions
                 this.resultsController = new RangeController();
+                this.resultsController.selection = [];
+
                 this.defineBinding("resultsController.content", {
                     "<-": "suggestions"
                 });


### PR DESCRIPTION
Sets the initial value of resultsController.selection to an empty array. See also: https://github.com/montagejs/montage/pull/1320
