### PR TITLE
Set progress' default value and max

### DIFF
--- a/ui/progress.reel/progress.js
+++ b/ui/progress.reel/progress.js
@@ -24,7 +24,7 @@ exports.Progress = NativeProgress.specialize(/** @lends module:"matte/ui/progres
 */
     _value: {
         enumerable: false,
-        value: null
+        value: 0
     },
 /**
         Description TODO
@@ -55,7 +55,7 @@ exports.Progress = NativeProgress.specialize(/** @lends module:"matte/ui/progres
 */
     _max: {
         enumerable: false,
-        value: null
+        value: 100
     },
 /**
         Description TODO


### PR DESCRIPTION
We need to be able to use the progress component without having to specific a default value or default max. Per the inline documentation, the default value is 0 and the default max is 100 but those properties were initialized to null

Most of the inner logic of the component expects value and max to be a number >= 0.
