### PR TITLE
Fix wrong class reference in loading.reel template

### DIFF
--- a/ui/loading.reel/loading.html
+++ b/ui/loading.reel/loading.html
@@ -18,12 +18,12 @@
 </head>
 <body>
     <div class="matte-Loading" data-montage-id="loading">
-        <div class="matte-Loading-section montage-Loading-l0"></div>
-        <div class="matte-Loading-section montage-Loading-l1"></div>
-        <div class="matte-Loading-section montage-Loading-l2"></div>
-        <div class="matte-Loading-section montage-Loading-l3"></div>
-        <div class="matte-Loading-section montage-Loading-l4"></div>
-        <div class="matte-Loading-section montage-Loading-l5"></div>
+        <div class="matte-Loading-section matte-Loading-l0"></div>
+        <div class="matte-Loading-section matte-Loading-l1"></div>
+        <div class="matte-Loading-section matte-Loading-l2"></div>
+        <div class="matte-Loading-section matte-Loading-l3"></div>
+        <div class="matte-Loading-section matte-Loading-l4"></div>
+        <div class="matte-Loading-section matte-Loading-l5"></div>
     </div>
 </body>
 </html>


### PR DESCRIPTION
loading.reel template is using different class name from css style.
