### PR TITLE
moved popup and show to constructorProperties

### DIFF
--- a/ui/popup/confirm.reel/confirm.js
+++ b/ui/popup/confirm.reel/confirm.js
@@ -51,19 +51,6 @@ var Confirm = exports.Confirm = Component.specialize(/** @lends module:"matte/ui
     _popup: {
         value: null
     },
-/**
-        Description TODO
-        @type {Function}
-        @default null
-    */
-    popup: {
-        set: function(value) {
-            this._popup = value;
-        },
-        get: function() {
-            return this._popup;
-        }
-    },
 
     okCallback: {value: null},
     cancelCallback: {value: null},
@@ -129,6 +116,22 @@ var Confirm = exports.Confirm = Component.specialize(/** @lends module:"matte/ui
             this.dispatchEvent(anEvent);
 
             this.popup.hide();
+        }
+    }
+    
+},{
+
+    /**
+    Description TODO
+    @type {Function}
+    @default null
+    */
+    popup: {
+        set: function(value) {
+            this._popup = value;
+        },
+        get: function() {
+            return this._popup;
         }
     },
 


### PR DESCRIPTION
for deprecation warning  `Confirm.show should be moved to constructorProperties`

i was getting this warning in my app, so in my app i had a customized copy of confirm.reel where i moved show and popup to the constructorProperties, and the deprecation warnings went away, but there were never any deprecation warnings with the test suite in matte, maybe i would need to add a test to tease it out... or maybe the example of Confirm.show that i followed is no longer normal, and we should be using an instance ie confirm.show?

tests before the changes  (chrome  32.0.1700.107)

```
[run all]300 specs, 40 failures in 22.595s @ 0:37:23Finished at Mon Feb 10 2014 00:37:23 GMT-0500 (EST)
```

tests after the changes  (chrome  32.0.1700.107)

```
300 specs, 40 failures in 27.511s @ 0:49:42Finished at Mon Feb 10 2014 00:49:42 GMT-0500 (EST)

```
